### PR TITLE
MPEG-4 AAC Decoder: check against invalid height info

### DIFF
--- a/libMpegTPDec/src/tpdec_asc.cpp
+++ b/libMpegTPDec/src/tpdec_asc.cpp
@@ -118,7 +118,9 @@ int  CProgramConfig_IsValid ( const CProgramConfig *pPce )
 
 /*
  * Read the extension for height info.
- * return 0 if successfull or -1 if the CRC failed.
+ * return 0 if successfull,
+ *       -1 if the CRC failed,
+ *       -2 if invalid HeightInfo.
  */
 static
 int CProgramConfig_ReadHeightExt(
@@ -146,15 +148,21 @@ int CProgramConfig_ReadHeightExt(
 
     for (i=0; i < pPce->NumFrontChannelElements; i++)
     {
-      pPce->FrontElementHeightInfo[i] = (UCHAR) FDKreadBits(bs,2);
+      if ((pPce->FrontElementHeightInfo[i] = (UCHAR) FDKreadBits(bs,2)) >= PC_NUM_HEIGHT_LAYER) {
+        err = -2; /* height information is out of the valid range */
+      }
     }
     for (i=0; i < pPce->NumSideChannelElements; i++)
     {
-      pPce->SideElementHeightInfo[i] = (UCHAR) FDKreadBits(bs,2);
+      if ((pPce->SideElementHeightInfo[i] = (UCHAR) FDKreadBits(bs,2)) >= PC_NUM_HEIGHT_LAYER) {
+        err = -2; /* height information is out of the valid range */
+      }
     }
     for (i=0; i < pPce->NumBackChannelElements; i++)
     {
-      pPce->BackElementHeightInfo[i] = (UCHAR) FDKreadBits(bs,2);
+      if ((pPce->BackElementHeightInfo[i] = (UCHAR) FDKreadBits(bs,2)) >= PC_NUM_HEIGHT_LAYER) {
+        err = -2; /* height information is out of the valid range */
+      }
     }
     FDKbyteAlign(bs, alignmentAnchor);
 
@@ -162,6 +170,13 @@ int CProgramConfig_ReadHeightExt(
     if ((USHORT)FDKreadBits(bs,8) != FDKcrcGetCRC(&crcInfo)) {
       /* CRC failed */
       err = -1;
+    }
+    if (err!=0) {
+      /* Reset whole height information in case an error occured during parsing. The return
+         value ensures that pPce->isValid is set to 0 and implicit channel mapping is used. */
+      FDKmemclear(pPce->FrontElementHeightInfo, sizeof(pPce->FrontElementHeightInfo));
+      FDKmemclear(pPce->SideElementHeightInfo, sizeof(pPce->SideElementHeightInfo));
+      FDKmemclear(pPce->BackElementHeightInfo, sizeof(pPce->BackElementHeightInfo));
     }
   }
   else {


### PR DESCRIPTION
In CProgramConfig_ReadHeightExt prevent stack overflow
 from invalid FrontElementHeightInfo array value.

Bug: 70637599
Test: see bug
Change-Id: I145414d81d7a7be711672c12f44b537c12eea308
(cherry picked from commit 772c7f5542e64f4a380e13e6263ab668694c7c4d)
(cherry picked from commit 1b9cbed05b4fd376677d67b6442aa30256834ed4)